### PR TITLE
Rubocop 1.23.0

### DIFF
--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -302,8 +302,6 @@ Style/Next:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
-Style/OptionalBooleanParameter:
-  Enabled: false
 Style/RaiseArgs:
   Enabled: false
 Style/RedundantBegin:

--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -1,0 +1,222 @@
+require:
+  - rubocop-rails
+
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.23.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.23/cops.html
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+  EnforcedStyle: no_space
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    inject: reduce
+    find_all: select
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+
+# Disabled cops
+Layout/ConditionPosition:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Enabled: false
+Lint/ElseLayout:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+Lint/RequireParentheses:
+  Enabled: false
+Lint/SuppressedException:
+  Enabled: false
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+Lint/Void:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+Naming/FileName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Rails/ActionFilter:
+  Enabled: false
+Rails/Delegate:
+  Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/IndexWith:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/ApplicationController:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/Attr:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/CharacterLiteral:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/NegatedWhile:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/VariableInterpolation:
+  Enabled: false
+Style/WhenThen:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+  

--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -62,6 +62,8 @@ Style/CollectionMethods:
     collect!: map!
     inject: reduce
     find_all: select
+Style/StringConcatenation:
+  Mode: conservative
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': '()'
@@ -185,6 +187,8 @@ Style/FormatString:
   Enabled: false
 Style/GlobalVars:
   Enabled: false
+Style/HashLikeCase:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
 Style/LambdaCall:
@@ -199,6 +203,8 @@ Style/Next:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
 Style/RaiseArgs:
   Enabled: false
 Style/RedundantBegin:
@@ -208,6 +214,8 @@ Style/RegexpLiteral:
 Style/RescueStandardError:
   Enabled: false
 Style/SignalException:
+  Enabled: false
+Style/SingleArgumentDig:
   Enabled: false
 Style/SpecialGlobalVars:
   Enabled: false
@@ -219,4 +227,3 @@ Style/WhenThen:
   Enabled: false
 Style/WhileUntilModifier:
   Enabled: false
-  

--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -22,6 +22,11 @@ AllCops:
 # The default config can be found at https://github.com/rubocop/rubocop/blob/v1.23.0/config/default.yml
 # Documentation can be found at https://docs.rubocop.org/rubocop/1.23/cops.html
 
+Gemspec/DateAssignment: # new in 1.10
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/HashAlignment:
@@ -31,9 +36,58 @@ Layout/HashAlignment:
   EnforcedColonStyle:
   - key
   - table
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
   EnforcedStyle: no_space
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
 
 Metrics/AbcSize:
   Exclude:
@@ -55,6 +109,13 @@ Naming/PredicateName:
   ForbiddenPrefixes:
   - is_
 
+Security/IoMethods: # new in 1.22
+  Enabled: true
+
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
@@ -62,8 +123,44 @@ Style/CollectionMethods:
     collect!: map!
     inject: reduce
     find_all: select
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
 Style/StringConcatenation:
   Mode: conservative
+Style/SwapValues: # new in 1.1
+  Enabled: true
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': '()'

--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -78,6 +78,7 @@ Lint/RequireRelativeSelfPath: # new in 1.22
   Enabled: true
 Lint/SymbolConversion: # new in 1.9
   Enabled: true
+  EnforcedStyle: consistent
 Lint/ToEnumArguments: # new in 1.1
   Enabled: true
 Lint/TripleQuotes: # new in 1.9
@@ -171,6 +172,7 @@ Style/WordArray:
 
 
 # Disabled cops
+
 Layout/ConditionPosition:
   Enabled: false
 Layout/EmptyLineAfterMagicComment:
@@ -315,6 +317,8 @@ Style/SignalException:
 Style/SingleArgumentDig:
   Enabled: false
 Style/SpecialGlobalVars:
+  Enabled: false
+Style/StringConcatenation:
   Enabled: false
 Style/TrivialAccessors:
   Enabled: false

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -27,8 +27,8 @@ Note: Anything you add to your local yml file will overwrite what is in the inhe
         ```
           prepare:
             fetch:
-              - url: "https://raw.githubusercontent.com/q-centrix/style-guides/main/ruby/.rubocop-0-77.yml"
-                path: ".rubocop-https---raw-githubusercontent-com-q-centrix-style-guides-main-ruby--rubocop-0-77-yml"
+            - url: "https://raw.githubusercontent.com/q-centrix/style-guides/main/ruby/.rubocop-0-77.yml"
+              path: ".rubocop-https---raw-githubusercontent-com-q-centrix-style-guides-main-ruby--rubocop-0-77-yml"
         ```
     2. The [rubocop channel](https://docs.codeclimate.com/docs/rubocop#using-rubocops-newer-versions) should specify the correct version. Available channels can be found [here](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)
         ```


### PR DESCRIPTION
Add config for rubocop 1.23.0
This version is necessary for upgrading to ruby 3.


Discussion about certain cop configs can be found here:
https://qcentrix.atlassian.net/wiki/spaces/~6406287afeb4b150c57860a9/pages/2011824133/Rubocop+settings#Rubocop-(new-from-0.77-to-1.23)