### PR TITLE
add configs that include rspec and graphql for v1.23.0

### DIFF
--- a/ruby/.rubocop-1-23-0-rspec-graphql.yml
+++ b/ruby/.rubocop-1-23-0-rspec-graphql.yml
@@ -380,7 +380,11 @@ RSpec/Rails/AvoidSetupHook: # new in 2.4
 # for rubocop-graphql
 # Documentation can be found at https://www.rubydoc.info/gems/rubocop-graphql/1.1.1/RuboCop/Cop/GraphQL
 
+GraphQL/GraphqlName:
+  Enabled: false
 GraphQL/MaxComplexitySchema:
   Enabled: false
 GraphQL/MaxDepthSchema:
+  Enabled: false
+GraphQL/ObjectDescription:
   Enabled: false

--- a/ruby/.rubocop-1-23-0-rspec-graphql.yml
+++ b/ruby/.rubocop-1-23-0-rspec-graphql.yml
@@ -331,6 +331,8 @@ Style/WhileUntilModifier:
 # for rubocop-rspec
 # Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.10/cops_rspec.html
 
+RSpec/AlignLeftLetBrace:
+  Enabled: true
 RSpec/AnyInstance:
   Enabled: false
 RSpec/DescribeClass:
@@ -352,6 +354,8 @@ RSpec/MessageChain:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/NamedSubject:
   Enabled: false

--- a/ruby/.rubocop-1-23-0-rspec-graphql.yml
+++ b/ruby/.rubocop-1-23-0-rspec-graphql.yml
@@ -1,0 +1,377 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-graphql
+
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.23.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.23/cops.html
+
+Gemspec/DateAssignment: # new in 1.10
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+  EnforcedStyle: no_space
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+  EnforcedStyle: consistent
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Security/IoMethods: # new in 1.22
+  Enabled: true
+
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    inject: reduce
+    find_all: select
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/StringConcatenation:
+  Mode: conservative
+Style/SwapValues: # new in 1.1
+  Enabled: true
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+
+# Disabled cops
+
+Layout/ConditionPosition:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Enabled: false
+Lint/ElseLayout:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+Lint/RequireParentheses:
+  Enabled: false
+Lint/SuppressedException:
+  Enabled: false
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+Lint/Void:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+Naming/FileName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Rails/ActionFilter:
+  Enabled: false
+Rails/Delegate:
+  Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/IndexWith:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/ApplicationController:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/Attr:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/CharacterLiteral:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/NegatedWhile:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/VariableInterpolation:
+  Enabled: false
+Style/WhenThen:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+
+
+# for rubocop-rspec
+
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/ExampleLength:
+  Max: 15
+RSpec/ExpectChange:
+  EnforcedStyle: block
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+RSpec/LetSetup:
+  Enabled: false
+RSpec/FilePath:
+  Enabled: false
+RSpec/MessageChain:
+  Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+
+# delete this section if we start using NewCops: enable
+
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true
+RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: true

--- a/ruby/.rubocop-1-23-0-rspec-graphql.yml
+++ b/ruby/.rubocop-1-23-0-rspec-graphql.yml
@@ -329,6 +329,7 @@ Style/WhileUntilModifier:
 
 
 # for rubocop-rspec
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.10/cops_rspec.html
 
 RSpec/AnyInstance:
   Enabled: false
@@ -375,3 +376,11 @@ RSpec/FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
 RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
+
+# for rubocop-graphql
+# Documentation can be found at https://www.rubydoc.info/gems/rubocop-graphql/1.1.1/RuboCop/Cop/GraphQL
+
+GraphQL/MaxComplexitySchema:
+  Enabled: false
+GraphQL/MaxDepthSchema:
+  Enabled: false

--- a/ruby/.rubocop-1-23-0-rspec.yml
+++ b/ruby/.rubocop-1-23-0-rspec.yml
@@ -1,0 +1,376 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.23.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.23/cops.html
+
+Gemspec/DateAssignment: # new in 1.10
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+  EnforcedStyle: no_space
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+  EnforcedStyle: consistent
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Security/IoMethods: # new in 1.22
+  Enabled: true
+
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    inject: reduce
+    find_all: select
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/StringConcatenation:
+  Mode: conservative
+Style/SwapValues: # new in 1.1
+  Enabled: true
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+
+# Disabled cops
+
+Layout/ConditionPosition:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Enabled: false
+Lint/ElseLayout:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+Lint/RequireParentheses:
+  Enabled: false
+Lint/SuppressedException:
+  Enabled: false
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+Lint/Void:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+Naming/FileName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Rails/ActionFilter:
+  Enabled: false
+Rails/Delegate:
+  Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/IndexWith:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/ApplicationController:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/Attr:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/CharacterLiteral:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/NegatedWhile:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/VariableInterpolation:
+  Enabled: false
+Style/WhenThen:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+
+
+# for rubocop-rspec
+
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/ExampleLength:
+  Max: 15
+RSpec/ExpectChange:
+  EnforcedStyle: block
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+RSpec/LetSetup:
+  Enabled: false
+RSpec/FilePath:
+  Enabled: false
+RSpec/MessageChain:
+  Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+
+# delete this section if we start using NewCops: enable
+
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true
+RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: true

--- a/ruby/.rubocop-1-23-0-rspec.yml
+++ b/ruby/.rubocop-1-23-0-rspec.yml
@@ -330,6 +330,8 @@ Style/WhileUntilModifier:
 # for rubocop-rspec
 # Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.10/cops_rspec.html
 
+RSpec/AlignLeftLetBrace:
+  Enabled: true
 RSpec/AnyInstance:
   Enabled: false
 RSpec/DescribeClass:
@@ -351,6 +353,8 @@ RSpec/MessageChain:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/NamedSubject:
   Enabled: false

--- a/ruby/.rubocop-1-23-0-rspec.yml
+++ b/ruby/.rubocop-1-23-0-rspec.yml
@@ -328,6 +328,7 @@ Style/WhileUntilModifier:
 
 
 # for rubocop-rspec
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.10/cops_rspec.html
 
 RSpec/AnyInstance:
   Enabled: false

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -37,3 +37,4 @@ Note: Anything you add to your local yml file will overwrite what is in the inhe
 2. `.rubocop.yml`
     1. Update the url you are inheriting from. This should match the url in your `codeclimate.yml`
 3. Make sure your `Gemfile` or `gemspec` specifies the same version of rubocop as the config you are using.
+4. If you are using a new type of cop for the first time (i.e. rspec or grpahql) you may need to add the gems to your gemfile.


### PR DESCRIPTION
Add configs that include rspec, and rspec+graphql (assuming that no one will need one with only graphql right now)

To test it, follow the [ReadMe instructions](https://github.com/q-centrix/style-guides/blob/main/ruby/README.md#with-every-update) and use the urls from this PR. (Change the endings to `style-guides/rubocop-rspec-1-23-0/ruby/.rubocop-1-23-0-rspec-graphql.yml` or `style-guides/rubocop-rspec-1-23-0/ruby/.rubocop-1-23-0-rspec.yml`)