### PR TITLE
disable Naming/VariableNumber

### DIFF
--- a/ruby/.rubocop-1-23-0-rspec-graphql.yml
+++ b/ruby/.rubocop-1-23-0-rspec-graphql.yml
@@ -236,6 +236,8 @@ Naming/FileName:
   Enabled: false
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+Naming/VariableNumber:
+  Enabled: false
 
 Rails/ActionFilter:
   Enabled: false

--- a/ruby/.rubocop-1-23-0-rspec.yml
+++ b/ruby/.rubocop-1-23-0-rspec.yml
@@ -235,6 +235,8 @@ Naming/FileName:
   Enabled: false
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+Naming/VariableNumber:
+  Enabled: false
 
 Rails/ActionFilter:
   Enabled: false

--- a/ruby/.rubocop-1-23-0.yml
+++ b/ruby/.rubocop-1-23-0.yml
@@ -234,6 +234,8 @@ Naming/FileName:
   Enabled: false
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+Naming/VariableNumber:
+  Enabled: false
 
 Rails/ActionFilter:
   Enabled: false


### PR DESCRIPTION
**_Summary and description of changes_**:
The rubocop committee decided that we don't care if a variable name with a number in it is camelcase or normalcase, so we are disabling this cop

Cop documentation: https://docs.rubocop.org/rubocop/cops_naming.html#namingvariablenumber

Slack conversation: https://qcx-dev.slack.com/archives/C05FT5GS6Q0/p1690590312773549

### **Important Merge Note:**
Ideally, we won't be changing configs after it has been implemented on repos, but we are on this one. My suspicion is that as soon as we merge this, the very next PR on every repo that is already on version 1.23.0 will show that X number of offenses were fixed (since we are disabling a cop, thankfully it will "fix" offenses instead of create them)