### PR TITLE
Limit rubocop factory bot

### DIFF
--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -208,8 +208,8 @@ GraphQL/MaxDepthSchema:
 # For this file, you will need the following gems:
   # gem 'rubocop', '~> 1.60.0'
   # gem 'rubocop-capybara'
-  # gem 'rubocop-factory_bot'
-  # gem 'rubocop-graphql'
+  # gem 'rubocop-factory_bot', '< 2.26.0'
+  # gem 'rubocop-graphql', '>= 1.5.2'
   # gem 'rubocop-performance'
   # gem 'rubocop-rails'
   # gem 'rubocop-rspec'

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -197,7 +197,7 @@ Performance/SelectMap:
 # For this file, you will need the following gems:
   # gem 'rubocop', '~> 1.60.0'
   # gem 'rubocop-capybara'
-  # gem 'rubocop-factory_bot'
+  # gem 'rubocop-factory_bot', '< 2.26.0'
   # gem 'rubocop-performance'
   # gem 'rubocop-rails'
   # gem 'rubocop-rspec'


### PR DESCRIPTION
**_Summary and description of changes_**:
until we go to rubocop v1.61 we need factory_bot limited, or else we get an error

Also include graphql version to stay above security issue