### PR TITLE
update negationmatcher enforced style

### DIFF
--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -174,6 +174,8 @@ RSpec/NestedGroups:
 
 # for rubocop-capybara
 # Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+Capybara/ClickLinkOrButtonStyle:
+  EnforcedStyle: link_or_button
 Capybara/NegationMatcher:
   EnforcedStyle: not_to
 

--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -172,6 +172,11 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: false
 
+# for rubocop-capybara
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+Capybara/NegationMatcher:
+  EnforcedStyle: not_to
+
 # for rubocop-performance
 # Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.20/cops_performance.html
 
@@ -181,8 +186,6 @@ Performance/ChainArrayAllocation:
   Enabled: true
 Performance/IoReadlines:
   Enabled: true
-# Performance/RangeInclude:
-#   Enabled: unsure
 Performance/SelectMap:
   Enabled: true
 

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -173,6 +173,8 @@ RSpec/NestedGroups:
 
 # for rubocop-capybara
 # Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+Capybara/ClickLinkOrButtonStyle:
+  EnforcedStyle: link_or_button
 Capybara/NegationMatcher:
   EnforcedStyle: not_to
 

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -171,6 +171,11 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: false
 
+# for rubocop-capybara
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+Capybara/NegationMatcher:
+  EnforcedStyle: not_to
+
 # for rubocop-performance
 # Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.20/cops_performance.html
 
@@ -180,8 +185,6 @@ Performance/ChainArrayAllocation:
   Enabled: true
 Performance/IoReadlines:
   Enabled: true
-# Performance/RangeInclude:
-#   Enabled: unsure
 Performance/SelectMap:
   Enabled: true
 


### PR DESCRIPTION
update negationmatcher enforced style because they changed it in v2.20.0 https://github.com/rubocop/rubocop-capybara/blob/main/CHANGELOG.md#2200-2024-01-03, but we want it to match the [Rspec/Rails/NegationBeValid](https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsnegationbevalid) cop
