### PR TITLE
Change Namespace for FilePath Cop

### DIFF
--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -127,6 +127,9 @@ Style/WordArray:
 # for rubocop-rails
 # Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.23/cops_rails.html
 
+
+Rails/FilePath:
+  Enabled: false
 Rails/FindBy:
   IgnoreWhereFirst: false
 Rails/HasManyOrHasOneDependent:
@@ -150,8 +153,6 @@ RSpec/ExampleLength:
 RSpec/ExpectChange:
   EnforcedStyle: block
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FilePath:
   Enabled: false
 RSpec/IndexedLet:
   Enabled: false

--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -207,7 +207,6 @@ GraphQL/MaxDepthSchema:
 # This affects the following repos
   # q-apps-models
   # q-apps-support
-  # data-science-integration
   # json_api_helpers
   # reporting-data-mart
 

--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -218,4 +218,4 @@ GraphQL/MaxDepthSchema:
   # gem 'rubocop-graphql', '>= 1.5.2'
   # gem 'rubocop-performance'
   # gem 'rubocop-rails'
-  # gem 'rubocop-rspec'
+  # gem 'rubocop-rspec', '>= 3.0.0'

--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -127,7 +127,6 @@ Style/WordArray:
 # for rubocop-rails
 # Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.23/cops_rails.html
 
-
 Rails/FilePath:
   Enabled: false
 Rails/FindBy:

--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -125,7 +125,7 @@ Style/WordArray:
   WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
 
 # for rubocop-rails
-# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.23/cops_rails.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.25/cops_rails.html
 
 Rails/FilePath:
   Enabled: false
@@ -141,7 +141,7 @@ Rails/WhereExists:
   EnforcedStyle: where
 
 # for rubocop-rspec
-# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.26/cops_rspec.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/3.0/cops_rspec.html
 
 RSpec/AlignLeftLetBrace:
   Enabled: true
@@ -173,14 +173,15 @@ RSpec/NestedGroups:
   Enabled: false
 
 # for rubocop-capybara
-# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/2.21/cops_capybara.html
+
 Capybara/ClickLinkOrButtonStyle:
   EnforcedStyle: link_or_button
 Capybara/NegationMatcher:
   EnforcedStyle: not_to
 
 # for rubocop-performance
-# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.20/cops_performance.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.21/cops_performance.html
 
 Performance/CaseWhenSplat:
   Enabled: true
@@ -192,7 +193,7 @@ Performance/SelectMap:
   Enabled: true
 
 # for rubocop-graphql
-# Documentation can be found at https://www.rubydoc.info/gems/rubocop-graphql/1.5.0/RuboCop/Cop/GraphQL
+# Documentation can be found at https://www.rubydoc.info/gems/rubocop-graphql/1.5.3/RuboCop/Cop/GraphQL
 
 GraphQL/GraphqlName:
   Enabled: false
@@ -202,7 +203,7 @@ GraphQL/MaxDepthSchema:
   Enabled: false
 
 
-# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `RSpec/Rails/InferredSpecType` in their local rubocop.yml
+# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `RSpecRails/InferredSpecType` in their local rubocop.yml
 # This affects the following repos
   # q-apps-models
   # q-apps-support
@@ -212,9 +213,10 @@ GraphQL/MaxDepthSchema:
 
 # For this file, you will need the following gems:
   # gem 'rubocop', '~> 1.60.0'
-  # gem 'rubocop-capybara'
-  # gem 'rubocop-factory_bot', '< 2.26.0'
-  # gem 'rubocop-graphql', '>= 1.5.2'
-  # gem 'rubocop-performance'
-  # gem 'rubocop-rails'
-  # gem 'rubocop-rspec', '>= 3.0.0'
+  # gem 'rubocop-capybara', '~>2.21.0'
+  # gem 'rubocop-factory_bot', '~> 2.25.0'
+  # gem 'rubocop-graphql', '~> 1.5.0'
+  # gem 'rubocop-performance', '~> 1.21.0'
+  # gem 'rubocop-rails', '~> 2.25.0'
+  # gem 'rubocop-rspec', '~> 3.0.0'
+  # gem 'rubocop-rspec_rails', '~> 2.30.0'

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -195,7 +195,6 @@ Performance/SelectMap:
 # This affects the following repos
   # q-apps-models
   # q-apps-support
-  # data-science-integration
   # json_api_helpers
   # reporting-data-mart
 

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -126,6 +126,8 @@ Style/WordArray:
 # for rubocop-rails
 # Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.23/cops_rails.html
 
+Rails/FilePath:
+  Enabled: false
 Rails/FindBy:
   IgnoreWhereFirst: false
 Rails/HasManyOrHasOneDependent:
@@ -149,8 +151,6 @@ RSpec/ExampleLength:
 RSpec/ExpectChange:
   EnforcedStyle: block
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FilePath:
   Enabled: false
 RSpec/IndexedLet:
   Enabled: false

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -124,7 +124,7 @@ Style/WordArray:
   WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
 
 # for rubocop-rails
-# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.23/cops_rails.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.25/cops_rails.html
 
 Rails/FilePath:
   Enabled: false
@@ -140,7 +140,7 @@ Rails/WhereExists:
   EnforcedStyle: where
 
 # for rubocop-rspec
-# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/2.26/cops_rspec.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/3.0/cops_rspec.html
 
 RSpec/AlignLeftLetBrace:
   Enabled: true
@@ -172,14 +172,14 @@ RSpec/NestedGroups:
   Enabled: false
 
 # for rubocop-capybara
-# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/2.21/cops_capybara.html
 Capybara/ClickLinkOrButtonStyle:
   EnforcedStyle: link_or_button
 Capybara/NegationMatcher:
   EnforcedStyle: not_to
 
 # for rubocop-performance
-# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.20/cops_performance.html
+# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.21/cops_performance.html
 
 Performance/CaseWhenSplat:
   Enabled: true
@@ -191,7 +191,7 @@ Performance/SelectMap:
   Enabled: true
 
 
-# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `Rspec/Rails/InferredSpecType` in their local rubocop.yml
+# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `RSpecRails/InferredSpecType` in their local rubocop.yml
 # This affects the following repos
   # q-apps-models
   # q-apps-support
@@ -201,8 +201,9 @@ Performance/SelectMap:
 
 # For this file, you will need the following gems:
   # gem 'rubocop', '~> 1.60.0'
-  # gem 'rubocop-capybara'
-  # gem 'rubocop-factory_bot', '< 2.26.0'
-  # gem 'rubocop-performance'
-  # gem 'rubocop-rails'
-  # gem 'rubocop-rspec', '>= 3.0.0'
+  # gem 'rubocop-capybara', '~>2.21.0'
+  # gem 'rubocop-factory_bot', '~> 2.25.0'
+  # gem 'rubocop-performance', '~> 1.21.0'
+  # gem 'rubocop-rails', '~> 2.25.0'
+  # gem 'rubocop-rspec', '~> 3.0.0'
+  # gem 'rubocop-rspec_rails', '~> 2.30.0'

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -205,4 +205,4 @@ Performance/SelectMap:
   # gem 'rubocop-factory_bot', '< 2.26.0'
   # gem 'rubocop-performance'
   # gem 'rubocop-rails'
-  # gem 'rubocop-rspec'
+  # gem 'rubocop-rspec', '>= 3.0.0'


### PR DESCRIPTION
**_JIRA Card_**: https://qcentrix.atlassian.net/browse/PLAY-7896
**_Summary and description of changes_**:
Incorporating the v 1.60 rubocop.yml into registries-implementations produced the following error:
`RSpec/FilePath has the wrong namespace - should be Rails`

By changing the namespace with in the v1.60 yaml, the error goes away for registries-implementations. 

Test:
```
bundle
bundle exec rubocop
```

Considerations:
This needs to be tested in other repos to make sure the requirement of bumping rubocop-rspec to 3.0.0 is compatible.