### PR TITLE
Count array, hash, heredoc, and method_calls as one

### DIFF
--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -78,10 +78,12 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 Metrics/ModuleLength:
   Max: 100
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 
 Naming/AccessorMethodName:
   Enabled: false

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -77,10 +77,12 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 Metrics/ModuleLength:
   Max: 100
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 
 Naming/AccessorMethodName:
   Enabled: false

--- a/ruby/.rubocop-1-60-no-rails.yml
+++ b/ruby/.rubocop-1-60-no-rails.yml
@@ -69,10 +69,12 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 Metrics/ModuleLength:
   Max: 100
   Exclude:
   - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
 
 Naming/AccessorMethodName:
   Enabled: false


### PR DESCRIPTION
## Summary
Sets arrays, hashes, herdocs, and method calls to be counted as 1 when checking MethodLength and ModuleLength.

While working on the following method, I received the `Metrics/MethodLength: Method has too many lines` error.  Since this was a heredoc, I think it shouldn't be counting all the lines:

```
    def start_end_date_query
      <<-SQL.squish
        (
          config_data->>'end_date' IS NOT NULL
          AND ?::DATE BETWEEN (config_data->>'start_date')::TEXT::DATE AND (config_data->>'end_date')::TEXT::DATE
        )
        OR
        (
          ?::DATE >= (config_data->>'start_date')::TEXT::DATE
          AND (config_data->>'end_date')::TEXT::DATE IS NULL
        )
        OR
        (
          config_data->>'start_date' IS NULL
          AND config_data->>'end_date' IS NULL
        )
      SQL
    end
```

## Robocop Links:
- [MethodLength](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/MethodLength)
- [ModuleLength](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ModuleLength)

## Testing

- On web, add the method above to any file and run rubocop on that file
- [ ] Confirm you can replicate the issue.

- On web, update .rubocop.yml so it inherits from the file from this PR:
```
inherit_from: https://raw.githubusercontent.com/q-centrix/style-guides/9b8d70f34b47b7c1c58509e2bee834fab367c285/ruby/.rubocop-1-60-all.yml
```
- [ ] Confirm you no longer see the issue.