### PR TITLE
Upgrade to 1 77 all.yml

### DIFF
--- a/ruby/.rubocop-1-77-all.yml
+++ b/ruby/.rubocop-1-77-all.yml
@@ -1,0 +1,245 @@
+
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-graphql
+  - rubocop-capybara
+  - rubocop-factory_bot
+  - rubocop-rspec_rails
+
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+  NewCops: enable
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.77.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.77/cops.html
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/LineContinuationSpacing:
+  EnforcedStyle: no_space
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+Lint/SymbolConversion:
+  EnforcedStyle: consistent
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Style/CollectionMethods:
+  Enabled: true
+Style/CollectionQuerying:
+  Enabled: false
+Style/ComparableBetween:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/HashLikeCase:
+  MinBranchesCount: 4
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/SafeNavigationChainLength:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/RaiseArgs:
+  Enabled: false
+Style/SignalException:
+  EnforcedStyle: semantic
+Style/SingleArgumentDig:
+  Enabled: false
+Style/StringConcatenation:
+  Mode: conservative
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+# for rubocop-rails
+# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.33/cops_rails.html
+
+Rails/CompactBlank:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  IgnoreWhereFirst: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/ToFormattedS:
+  EnforcedStyle: to_formatted_s
+Rails/WhereExists:
+  EnforcedStyle: where
+
+# for rubocop-rspec
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/3.7/cops_rspec.html
+
+RSpec/AlignLeftLetBrace:
+  Enabled: true
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/ExampleLength:
+  Max: 15
+RSpec/ExpectChange:
+  EnforcedStyle: block
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/IndexedLet:
+  Enabled: false
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+RSpec/LetSetup:
+  Enabled: false
+RSpec/MessageChain:
+  Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+
+# for rubocop-capybara
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html
+
+
+Capybara/AmbiguousClick:
+  Enabled: false
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+Capybara/NegationMatcherAfterVisit:
+  Enabled: false
+Capybara/NegationMatcher:
+  EnforcedStyle: not_to
+
+# for rubocop-performance
+# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.26/cops_performance.html
+
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: true
+
+# for rubocop-graphql
+# Documentation can be found at https://www.rubydoc.info/gems/rubocop-graphql/1.5.6/RuboCop/Cop/GraphQL
+
+GraphQL/GraphqlName:
+  Enabled: false
+GraphQL/MaxComplexitySchema:
+  Enabled: false
+GraphQL/MaxDepthSchema:
+  Enabled: false
+
+# for Factory_bot
+# Documentation can be found at https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html
+
+FactoryBot/AssociationStyle:
+  Enabled: false
+
+# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `RSpec/Rails/InferredSpecType` in their local rubocop.yml
+# This affects the following repos
+  # q-apps-models
+  # q-apps-support
+  # json_api_helpers
+  # reporting-data-mart
+
+# For this file, you will need the following gems:
+  # gem 'rubocop', '~> 1.77.0'
+  # gem 'rubocop-capybara', '~> 2.22.0'
+  # gem 'rubocop-factory_bot', '~> 2.27.1'
+  # gem 'rubocop-graphql', '~> 1.5.6'
+  # gem 'rubocop-performance', '~> 1.26.0'
+  # gem 'rubocop-rails', '~> 2.33.3'
+  # gem 'rubocop-rspec', '>= 3.7.0'
+  # gem 'rubocop-rspec_rails', '~> 2.31.0'

--- a/ruby/.rubocop-1-77-all.yml
+++ b/ruby/.rubocop-1-77-all.yml
@@ -1,5 +1,5 @@
 
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance

--- a/ruby/.rubocop-1-77-all.yml
+++ b/ruby/.rubocop-1-77-all.yml
@@ -1,4 +1,3 @@
-
 plugins:
   - rubocop-rails
   - rubocop-rspec

--- a/ruby/.rubocop-1-77-all.yml
+++ b/ruby/.rubocop-1-77-all.yml
@@ -94,7 +94,7 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
   - is_
 

--- a/ruby/.rubocop-1-77-except-graphql.yml
+++ b/ruby/.rubocop-1-77-except-graphql.yml
@@ -226,7 +226,6 @@ FactoryBot/AssociationStyle:
 # For this file, you will need the following gems:
   # gem 'rubocop', '~> 1.77.0'
   # gem 'rubocop-capybara', '~> 2.22.0'
-  # gem 'rubocop-graphql', '~> 1.5.6'
   # gem 'rubocop-performance', '~> 1.26.0'
   # gem 'rubocop-rails', '~> 2.33.3'
   # gem 'rubocop-rspec', '>= 3.7.0'

--- a/ruby/.rubocop-1-77-except-graphql.yml
+++ b/ruby/.rubocop-1-77-except-graphql.yml
@@ -1,0 +1,233 @@
+
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-capybara
+  - rubocop-factory_bot
+  - rubocop-rspec_rails
+
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+  NewCops: enable
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.77.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.77/cops.html
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/LineContinuationSpacing:
+  EnforcedStyle: no_space
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+Lint/SymbolConversion:
+  EnforcedStyle: consistent
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Style/CollectionMethods:
+  Enabled: true
+Style/CollectionQuerying:
+  Enabled: false
+Style/ComparableBetween:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/HashLikeCase:
+  MinBranchesCount: 4
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/SafeNavigationChainLength:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/RaiseArgs:
+  Enabled: false
+Style/SignalException:
+  EnforcedStyle: semantic
+Style/SingleArgumentDig:
+  Enabled: false
+Style/StringConcatenation:
+  Mode: conservative
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+# for rubocop-rails
+# Documentation can be found at https://docs.rubocop.org/rubocop-rails/2.33/cops_rails.html
+
+Rails/CompactBlank:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  IgnoreWhereFirst: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/ToFormattedS:
+  EnforcedStyle: to_formatted_s
+Rails/WhereExists:
+  EnforcedStyle: where
+
+# for rubocop-rspec
+# Documentation can be found at https://docs.rubocop.org/rubocop-rspec/3.7/cops_rspec.html
+
+RSpec/AlignLeftLetBrace:
+  Enabled: true
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/ExampleLength:
+  Max: 15
+RSpec/ExpectChange:
+  EnforcedStyle: block
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/IndexedLet:
+  Enabled: false
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+RSpec/LetSetup:
+  Enabled: false
+RSpec/MessageChain:
+  Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+
+# for rubocop-capybara
+# Documentation can be found at https://docs.rubocop.org/rubocop-capybara/cops_capybara.html
+
+
+Capybara/AmbiguousClick:
+  Enabled: false
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+Capybara/NegationMatcherAfterVisit:
+  Enabled: false
+Capybara/NegationMatcher:
+  EnforcedStyle: not_to
+
+# for rubocop-performance
+# Documentation can be found at https://docs.rubocop.org/rubocop-performance/1.26/cops_performance.html
+
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: true
+
+# for Factory_bot
+# Documentation can be found at https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html
+
+FactoryBot/AssociationStyle:
+  Enabled: false
+
+# Repos that do not have `config.infer_spec_type_from_file_location!` will want to disable `RSpec/Rails/InferredSpecType` in their local rubocop.yml
+# This affects the following repos
+  # q-apps-models
+  # q-apps-support
+  # json_api_helpers
+  # reporting-data-mart
+
+# For this file, you will need the following gems:
+  # gem 'rubocop', '~> 1.77.0'
+  # gem 'rubocop-capybara', '~> 2.22.0'
+  # gem 'rubocop-graphql', '~> 1.5.6'
+  # gem 'rubocop-performance', '~> 1.26.0'
+  # gem 'rubocop-rails', '~> 2.33.3'
+  # gem 'rubocop-rspec', '>= 3.7.0'
+  # gem 'rubocop-rspec_rails', '~> 2.31.0'

--- a/ruby/.rubocop-1-77-except-graphql.yml
+++ b/ruby/.rubocop-1-77-except-graphql.yml
@@ -1,4 +1,3 @@
-
 plugins:
   - rubocop-rails
   - rubocop-rspec

--- a/ruby/.rubocop-1-77-except-graphql.yml
+++ b/ruby/.rubocop-1-77-except-graphql.yml
@@ -1,5 +1,5 @@
 
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
@@ -93,7 +93,7 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
   - is_
 

--- a/ruby/.rubocop-1-77-no-rails.yml
+++ b/ruby/.rubocop-1-77-no-rails.yml
@@ -84,7 +84,7 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
   - is_
 

--- a/ruby/.rubocop-1-77-no-rails.yml
+++ b/ruby/.rubocop-1-77-no-rails.yml
@@ -1,0 +1,131 @@
+AllCops:
+  Exclude:
+    - '**/*.axlsx'
+    - '.git/**/*'
+    - 'bin/**/*'
+    - 'circle.yml'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'Guardfile'
+    - 'Gemfile'
+    - 'Gemfile.lock'
+    - 'node_modules/**/*'
+    - 'Rakefile'
+    - 'README.md'
+    - 'spec/dummy/**/*'
+    - 'vendor/**/*'
+  NewCops: enable
+
+# If the cop is not mentioned here, then we are using the defualts cops
+# The default config can be found at https://github.com/rubocop/rubocop/blob/v1.77.0/config/default.yml
+# Documentation can be found at https://docs.rubocop.org/rubocop/1.77/cops.html
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
+Layout/LineContinuationSpacing:
+  EnforcedStyle: no_space
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Lint/AmbiguousOperator:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Lint/Loop:
+  Enabled: false
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+Lint/SymbolConversion:
+  EnforcedStyle: consistent
+
+Metrics/AbcSize:
+  Exclude:
+  - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+  - lib/tasks/**/*
+  - spec/**/*
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+Metrics/ModuleLength:
+  Max: 100
+  Exclude:
+  - spec/**/*
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Style/CollectionMethods:
+  Enabled: true
+Style/CollectionQuerying:
+  Enabled: false
+Style/ComparableBetween:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/HashLikeCase:
+  MinBranchesCount: 4
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/SafeNavigationChainLength:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'
+Style/RaiseArgs:
+  Enabled: false
+Style/SignalException:
+  EnforcedStyle: semantic
+Style/SingleArgumentDig:
+  Enabled: false
+Style/StringConcatenation:
+  Mode: conservative
+Style/WordArray:
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+
+
+# For this file, you will need the following gems:
+  # gem 'rubocop', '~> 1.77.0'


### PR DESCRIPTION
**_JIRA Card_**: https://qcentrix.atlassian.net/browse/CV-9194
**_Summary and description of changes_**:
Upgrading the shared rubocop yml files to the most recent versions approved by the rubocop committee.

Also, included the use of plugin instead of require and corrected a name change to one of the cops.

To test:
-- Configured registries-implementations pointing to branch and latest gems. Ran rubocop on ruby and spec files
-- Configured registries-api. Ran rubocop on graphql and spec/factories files.
-- Configured reg-test. Ran rubocop on features

Smoke tested the configuration .rubocop-1-77-except-graphql.yml and .rubocop-1-77-no-rails.yml
