### PR TITLE
disable RedundantPresenceValidation

### DIFF
--- a/ruby/.rubocop-1-60-all.yml
+++ b/ruby/.rubocop-1-60-all.yml
@@ -138,6 +138,8 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 Rails/ToFormattedS:
   EnforcedStyle: to_formatted_s
 Rails/WhereExists:

--- a/ruby/.rubocop-1-60-except-graphql.yml
+++ b/ruby/.rubocop-1-60-except-graphql.yml
@@ -137,6 +137,8 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 Rails/ToFormattedS:
   EnforcedStyle: to_formatted_s
 Rails/WhereExists:

--- a/ruby/.rubocop-1-77-all.yml
+++ b/ruby/.rubocop-1-77-all.yml
@@ -150,6 +150,8 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 Rails/ToFormattedS:
   EnforcedStyle: to_formatted_s
 Rails/WhereExists:

--- a/ruby/.rubocop-1-77-except-graphql.yml
+++ b/ruby/.rubocop-1-77-except-graphql.yml
@@ -149,6 +149,8 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 Rails/ToFormattedS:
   EnforcedStyle: to_formatted_s
 Rails/WhereExists:


### PR DESCRIPTION
**_JIRA Card_**: https://qcentrix.atlassian.net/browse/ACS-8268

**_Summary and description of changes_**:
Our configuration for `Rails/RedundantPresenceValidationOnBelongsTo` https://docs.rubocop.org/rubocop-rails/2.20/cops_rails.html#railsredundantpresencevalidationonbelongsto does not match our config. We have it set to false in web, so the cop enforces the opposite of what we want.